### PR TITLE
Fix unchosen section display

### DIFF
--- a/new/templates/dashboard.html
+++ b/new/templates/dashboard.html
@@ -1692,27 +1692,6 @@
             }
         }
         
-        function setupEventListeners() {
-            // SECTIONS is already an array, so we can use it directly
-            const sectionsArray = SECTIONS;
-            
-            // Section selection is now handled by radio button event listeners in loadSections()
-            
-            // Manual section selection
-            const manualSectionSelect = document.getElementById('manualSectionSelect');
-            if (manualSectionSelect) {
-                manualSectionSelect.addEventListener('change', function() {
-                    const sectionId = this.value;
-                    if (sectionId) {
-                        // Populate student dropdown based on selected section
-                        const selectedSection = sectionsArray.find(s => s.id === sectionId);
-                        if (selectedSection) {
-                            populateManualStudentSelect(selectedSection);
-                        }
-                    }
-                });
-            }
-            
         // Function to handle section change from radio buttons
         function handleSectionChange(sectionId) {
             if (!sectionId) return;
@@ -1739,6 +1718,27 @@
                 loadAttendanceData();
             }
         }
+        
+        function setupEventListeners() {
+            // SECTIONS is already an array, so we can use it directly
+            const sectionsArray = SECTIONS;
+            
+            // Section selection is now handled by radio button event listeners in loadSections()
+            
+            // Manual section selection
+            const manualSectionSelect = document.getElementById('manualSectionSelect');
+            if (manualSectionSelect) {
+                manualSectionSelect.addEventListener('change', function() {
+                    const sectionId = this.value;
+                    if (sectionId) {
+                        // Populate student dropdown based on selected section
+                        const selectedSection = sectionsArray.find(s => s.id === sectionId);
+                        if (selectedSection) {
+                            populateManualStudentSelect(selectedSection);
+                        }
+                    }
+                });
+            }
             
             // Start session
             document.getElementById('startSession').addEventListener('click', function() {


### PR DESCRIPTION
Move `handleSectionChange` to the global scope to fix section selection not working.

The `handleSectionChange` function was defined within `setupEventListeners`, making it inaccessible when `loadSections` attempted to call it for radio button event listeners and default section initialization. Moving it to the global scope ensures it's available when needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d450817-c0e9-4a90-ba07-098881caf812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d450817-c0e9-4a90-ba07-098881caf812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

